### PR TITLE
pciutils: fix the build warning

### DIFF
--- a/common.c
+++ b/common.c
@@ -62,7 +62,7 @@ set_pci_method(struct pci_access *pacc, char *arg)
   if (!strcmp(arg, "help"))
     {
       printf("Known PCI access methods:\n\n");
-      for (i=0; name = pci_get_method_name(i); i++)
+      for (i=0; (name = pci_get_method_name(i)) != NULL; i++)
 	if (name[0])
 	  printf("%s\n", name);
       exit(0);
@@ -83,7 +83,7 @@ set_pci_option(struct pci_access *pacc, char *arg)
     {
       struct pci_param *p;
       printf("Known PCI access parameters:\n\n");
-      for (p=NULL; p=pci_walk_params(pacc, p);)
+      for (p=NULL; (p=pci_walk_params(pacc, p)) != NULL;)
 	printf("%-20s %s (%s)\n", p->param, p->help, p->value);
       exit(0);
     }

--- a/lib/caps.c
+++ b/lib/caps.c
@@ -94,7 +94,7 @@ pci_free_caps(struct pci_dev *d)
 {
   struct pci_cap *cap;
 
-  while (cap = d->first_cap)
+  while ((cap = d->first_cap) != NULL)
     {
       d->first_cap = cap->next;
       pci_mfree(cap);

--- a/lib/dump.c
+++ b/lib/dump.c
@@ -79,8 +79,8 @@ dump_init(struct pci_access *a)
 	*z-- = 0;
       len = z - buf + 1;
       mn = 0;
-      if (dump_validate(buf, "##:##.# ") && sscanf(buf, "%x:%x.%d", &bn, &dn, &fn) == 3 ||
-	  dump_validate(buf, "####:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4)
+      if ((dump_validate(buf, "##:##.# ") && sscanf(buf, "%x:%x.%d", &bn, &dn, &fn) == 3) ||
+	  (dump_validate(buf, "####:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4))
 	{
 	  dev = pci_get_dev(a, mn, bn, dn, fn);
 	  dump_alloc_data(dev, 256);

--- a/lib/generic.c
+++ b/lib/generic.c
@@ -29,7 +29,7 @@ pci_generic_scan_bus(struct pci_access *a, byte *busmap, int bus)
     {
       t->dev = dev;
       multi = 0;
-      for (t->func=0; !t->func || multi && t->func<8; t->func++)
+      for (t->func=0; !t->func || (multi && t->func<8); t->func++)
 	{
 	  u32 vd = pci_read_long(t, PCI_VENDOR_ID);
 	  struct pci_dev *d;

--- a/lib/names.c
+++ b/lib/names.c
@@ -26,7 +26,7 @@ static char *id_lookup(struct pci_access *a, int flags, int cat, int id1, int id
 	}
       if (flags & PCI_LOOKUP_NETWORK)
         {
-	  if (name = pci_id_net_lookup(a, cat, id1, id2, id3, id4))
+	  if ((name = pci_id_net_lookup(a, cat, id1, id2, id3, id4)) != NULL)
 	    {
 	      pci_id_insert(a, cat, id1, id2, id3, id4, name, SRC_NET);
 	      pci_mfree(name);

--- a/lib/params.c
+++ b/lib/params.c
@@ -67,7 +67,7 @@ pci_free_params(struct pci_access *acc)
 {
   struct pci_param *p;
 
-  while (p = acc->params)
+  while ((p = acc->params) != NULL)
     {
       acc->params = p->next;
       if (p->value_malloced)

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -206,7 +206,7 @@ sysfs_fill_slots(struct pci_access *a)
   if (!dir)
     return;
 
-  while (entry = readdir(dir))
+  while ((entry = readdir(dir)) != NULL)
     {
       char namebuf[OBJNAMELEN], buf[16];
       FILE *file;

--- a/ls-kernel.c
+++ b/ls-kernel.c
@@ -38,7 +38,7 @@ load_pcimap(void)
     return;
   tried_pcimap = 1;
 
-  if (name = opt_pcimap)
+  if ((name = opt_pcimap) != NULL)
     {
       f = fopen(name, "r");
       if (!f)
@@ -132,7 +132,7 @@ find_driver(struct device *d, char *buf)
     return "<name-too-long>";
   buf[n] = 0;
 
-  if (drv = strrchr(buf, '/'))
+  if ((drv = strrchr(buf, '/')) != NULL)
     return drv+1;
   else
     return buf;
@@ -145,7 +145,7 @@ show_kernel(struct device *d)
   char *driver;
   struct pcimap_entry *e, *last = NULL;
 
-  if (driver = find_driver(d, buf))
+  if ((driver = find_driver(d, buf)) != NULL)
     printf("\tKernel driver in use: %s\n", driver);
 
   load_pcimap();
@@ -166,7 +166,7 @@ show_kernel_machine(struct device *d)
   char *driver;
   struct pcimap_entry *e, *last = NULL;
 
-  if (driver = find_driver(d, buf))
+  if ((driver = find_driver(d, buf)) != NULL)
     printf("Driver:\t%s\n", driver);
 
   load_pcimap();

--- a/ls-map.c
+++ b/ls-map.c
@@ -76,7 +76,7 @@ do_map_bus(int bus)
 		  if (verbose)
 		    printf("Discovered device %02x:%02x.%d\n", bus, dev, func);
 		  bi->exists = 1;
-		  if (d = scan_device(p))
+		  if ((d = scan_device(p)) != NULL)
 		    {
 		      show_device(d);
 		      switch (get_conf_byte(d, PCI_HEADER_TYPE) & 0x7f)

--- a/ls-vpd.c
+++ b/ls-vpd.c
@@ -161,8 +161,8 @@ cap_vpd(struct device *d)
 		break;
 
 	      /* Is this item known? */
-	      for (item=vpd_items; item->id1 && item->id1 != id1 ||
-				   item->id2 && item->id2 != id2; item++)
+	      for (item=vpd_items; (item->id1 && item->id1 != id1) ||
+				   (item->id2 && item->id2 != id2); item++)
 		;
 
 	      /* Only read the first byte of the RV field because the

--- a/lspci.c
+++ b/lspci.c
@@ -150,7 +150,7 @@ scan_devices(void)
 
   pci_scan_bus(pacc);
   for (p=pacc->devices; p; p=p->next)
-    if (d = scan_device(p))
+    if ((d = scan_device(p)) != NULL)
       {
 	d->next = first_dev;
 	first_dev = d;
@@ -291,7 +291,7 @@ show_terse(struct device *d)
 	 pci_lookup_name(pacc, devbuf, sizeof(devbuf),
 			 PCI_LOOKUP_VENDOR | PCI_LOOKUP_DEVICE,
 			 p->vendor_id, p->device_id));
-  if (c = get_conf_byte(d, PCI_REVISION_ID))
+  if ((c = get_conf_byte(d, PCI_REVISION_ID)) != 0)
     printf(" (rev %02x)", c);
   if (verbose)
     {
@@ -846,9 +846,9 @@ show_machine(struct device *d)
 	}
       if (p->phy_slot)
 	printf("PhySlot:\t%s\n", p->phy_slot);
-      if (c = get_conf_byte(d, PCI_REVISION_ID))
+      if ((c = get_conf_byte(d, PCI_REVISION_ID)) != 0)
 	printf("Rev:\t%02x\n", c);
-      if (c = get_conf_byte(d, PCI_CLASS_PROG))
+      if ((c = get_conf_byte(d, PCI_CLASS_PROG)) != 0)
 	printf("ProgIf:\t%02x\n", c);
       if (opt_kernel)
 	show_kernel_machine(d);
@@ -859,9 +859,9 @@ show_machine(struct device *d)
       print_shell_escaped(pci_lookup_name(pacc, classbuf, sizeof(classbuf), PCI_LOOKUP_CLASS, p->device_class));
       print_shell_escaped(pci_lookup_name(pacc, vendbuf, sizeof(vendbuf), PCI_LOOKUP_VENDOR, p->vendor_id, p->device_id));
       print_shell_escaped(pci_lookup_name(pacc, devbuf, sizeof(devbuf), PCI_LOOKUP_DEVICE, p->vendor_id, p->device_id));
-      if (c = get_conf_byte(d, PCI_REVISION_ID))
+      if ((c = get_conf_byte(d, PCI_REVISION_ID)) != 0)
 	printf(" -r%02x", c);
-      if (c = get_conf_byte(d, PCI_CLASS_PROG))
+      if ((c = get_conf_byte(d, PCI_CLASS_PROG)) != 0)
 	printf(" -p%02x", c);
       if (sv_id && sv_id != 0xffff)
 	{
@@ -936,11 +936,11 @@ main(int argc, char **argv)
 	pacc->buscentric = 1;
 	break;
       case 's':
-	if (msg = pci_filter_parse_slot(&filter, optarg))
+	if ((msg = pci_filter_parse_slot(&filter, optarg)) != NULL)
 	  die("-s: %s", msg);
 	break;
       case 'd':
-	if (msg = pci_filter_parse_id(&filter, optarg))
+	if ((msg = pci_filter_parse_id(&filter, optarg)) != NULL)
 	  die("-d: %s", msg);
 	break;
       case 'x':


### PR DESCRIPTION
some build warning :using the result of an assignment as a condition without parentheses [-Werror,-Wparentheses]
under some build envrionment, if build config contains the error of parentheses, the build will fail.
so add the parenthese to make the code solid, and fix the build warning.

Tracked-On: OAM-84055
Signed-off-by: chenxia1 <xiao.x.chen@intel.com>