### PR TITLE
coverity: fix the overlapping_copy in pciutils-intel lib/dump.c

### DIFF
--- a/lib/dump.c
+++ b/lib/dump.c
@@ -106,7 +106,8 @@ dump_init(struct pci_access *a)
 	      if (i >= dd->allocated)	/* Need to re-allocate the buffer */
 		{
 		  dump_alloc_data(dev, 4096);
-		  memcpy(((struct dump_data *) dev->aux)->data, dd->data, 256);
+		  // Use memmove instead of memcpy to handle potential overlapping memory.
+		  memmove(((struct dump_data *) dev->aux)->data, dd->data, 256);
 		  pci_mfree(dd);
 		  dd = dev->aux;
 		}


### PR DESCRIPTION
Use memmove instead of memcpy to handle potential overlapping memory

Tracked-On: OAM-124666